### PR TITLE
Fix some lua pattern escaping

### DIFF
--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -4,6 +4,8 @@
 -- @copyright Olivier DOSSMANN
 -------------------------------------------------------------------------------
 
+local lfs = require "lfs"
+
 --- Split a string using '@sep' separator
 -- @param sep char to split string
 -- @usage 'a string, with some words':split(',')

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -500,7 +500,7 @@ end
 function utils.keepUnreservedChars(string)
   -- In chap 2.3 a list of reserved chars are given. We use this list
   -- and replace them by _
-  local reserved_chars = '[\:\/\?\#\@\!\$\&\'()*+,;=%]\[]'
+  local reserved_chars = "[:/%?#%]%[@!%$&'()%*%+,;=]"
   local res = string.gsub(string, reserved_chars, '_') or string
   return res
 end

--- a/makefly
+++ b/makefly
@@ -1,4 +1,22 @@
-#!/usr/bin/env lua
+#!/bin/sh
+
+_=[[
+	: ${BIN:=$(command -v lua)}
+	if [ -n "$BIN" ]; then
+		"$BIN" -e 'require"os".exit( _VERSION:find(" 5%.1") and 0 or 1)' || BIN=""
+	fi
+	: ${BIN:=$(command -v lua5.1)}
+	: ${BIN:=$(command -v lua-5.1)}
+	: ${BIN:=$(command -v luajit)}
+	exec "$BIN" "$0" "$@"
+	exit $?
+]]
+_=nil
+
+if not _VERSION:find(" 5%.1") then
+	print("Warning: the current makefly version is not compatible with Lua 5.2+")
+	require("os").exit(1)
+end
 
 --[[
 

--- a/makefly
+++ b/makefly
@@ -63,7 +63,7 @@ local function clean(args)
     print(string.format(_('[%s] Missing: %s directory'), display_warning, config.tmppath))
   end
   local docpath = currentpath .. '/' .. config.docdir
-  local docextension = string.gsub(config.PAGE_EXT, '\.(.*)', '%1')
+  local docextension = string.gsub(config.PAGE_EXT, '%.(.*)', '%1')
   local docfiles = utils.listing(docpath, docextension)
   for _, filepath in pairs(docfiles) do
     os.remove(filepath)
@@ -254,7 +254,7 @@ local function doc(args)
     final:push(footer)
     local res = utils.replace(final:flatten(), substitutions)
     -- write result into a file
-    local name = string.gsub(path, "(.*/)(.*)(\.md)", "%2")
+    local name = string.gsub(path, "(.*/)(.*)(%.md)", "%2")
     local filepath = directory .. '/' .. name .. config.PAGE_EXT
     local file = assert(io.open(filepath, 'wb'))
     file:write(res)

--- a/tools/create_post.sh
+++ b/tools/create_post.sh
@@ -28,7 +28,7 @@
 ## VARIABLES
 ###
 LIMIT='255'
-YOUR_EDITOR=`which nano`
+YOUR_EDITOR="$(which editor || which nano)"
 QUIET=0
 
 #####


### PR DESCRIPTION
The magic characters must be escaped with `%` (not `\` ).
The magic characters are `^$()%.[]*+-?` (see the [Lua documentation](http://www.lua.org/manual/5.1/manual.html#5.4.1))
